### PR TITLE
Upload error log as artifact on GitLab

### DIFF
--- a/gitlab/hermes-ci.yml
+++ b/gitlab/hermes-ci.yml
@@ -78,7 +78,9 @@
   tags:
     - docker
   artifacts:
-    paths: [".hermes/"]
+    paths: [".hermes/", "hermes.log"]
+    when: always
+    expire_in: 1 year
 
 # hermes metadata preparation - this job creates a MR that will trigger deposition when merged.
 .hermes_curate:


### PR DESCRIPTION
Made the following changes to hermes-ci.yml
1) Upload artifacts also for failed jobs
2) Include the "hermes.log" in the artifact paths